### PR TITLE
Fix 13880

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue where a start >= end will always return last item.
+  https://dev.plone.org/ticket/13880\
+  [thepjot]
 
 
 1.0.1 (2014-01-27)

--- a/plone/batching/batch.py
+++ b/plone/batching/batch.py
@@ -37,7 +37,10 @@ class BaseBatch(object):
         self.orphan = orphan
         self.overlap = overlap
         self.pagerange = pagerange
-
+        self.beyond = False
+        # Special use case, where the start is bigger than the sequence
+        if start > len(sequence):
+            self.beyond = True
         self.initialize(start, end, size)
 
     def initialize(self, start, end, size):
@@ -51,6 +54,8 @@ class BaseBatch(object):
         self.end = end
 
         self.first = max(start - 1, 0)
+        if self.beyond:
+            self.first = self.end
         self.length = self.end - self.first
 
         self.last = self.sequence_length - size

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -104,6 +104,36 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch), [5, 6, 7, 8, 9])
 
 
+    def test_batch_bsize(self):
+        sequence = range(279)
+        # Random page
+        batch = BaseBatch(sequence, 10, start=80)
+        self.assertEqual(batch.length, 10)
+
+        # Last page
+        batch = BaseBatch(sequence, 10, start=270)
+        self.assertEqual(batch.length, 9)
+
+        # Beyond last page
+        batch = BaseBatch(sequence, 10, start=280)
+        self.assertEqual(batch.length, 0)
+
+        # Single item batch
+        batch = BaseBatch(range(1), 10)
+        self.assertEqual(batch.length, 1)
+
+        # Small sequence batch (to cover plone.z3cform.crud)
+        small_sequence = range(3)
+        # Page 1
+        batch = BaseBatch.fromPagenumber(small_sequence, 2, 1)
+        self.assertEqual(batch.length, 2)        
+
+        # Page 2
+        batch = BaseBatch.fromPagenumber(small_sequence, 2, 2)
+        self.assertEqual(batch.length, 1)        
+
+
+
 class TestQuantumBatch(unittest.TestCase):
 
     def test_quantumbatch(self):


### PR DESCRIPTION
@davisagli  Sorry for the spam. This fix works with plone.z3cform (master) as well. I've included a test to cover the test that was failing there.

If start is beyond the range of the sequence. Set a flag saying so, so we can prevent the batch from spewing out the last item.
