### PR TITLE
fix for "plone.batching fails if b_start is too high" see plone/Products.CMFPlone#639

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure pagenumber value is not bigger that numpages
+  or it fails in previous_pages when using orphan
+  [gbastien]
 
 
 1.0.4 (2015-04-28)

--- a/plone/batching/batch.py
+++ b/plone/batching/batch.py
@@ -56,22 +56,23 @@ class BaseBatch(object):
         self.end = end
 
         self.first = max(start - 1, 0)
+        if self.beyond:
+            self.first = self.end
+        self.length = self.end - self.first
+
         self.last = self.sequence_length - size
 
         # Set up the total number of pages
         self.numpages = calculate_pagenumber(
             self.sequence_length - self.orphan, self.pagesize, self.overlap)
 
-        if self.beyond:
-            self.first = self.end
-            # Make sure current page number is not > numpages
-            self._pagenumber = self.numpages
-        else:
-            # Set up the current page number
-            self._pagenumber = calculate_pagenumber(
-                self.start, self.pagesize, self.overlap)
+        # Set up the current page number
+        self._pagenumber = calculate_pagenumber(
+            self.start, self.pagesize, self.overlap)
 
-        self.length = self.end - self.first
+        # Make sure self._pagenumber is <= self.numpages
+        if self._pagenumber > self.numpages:
+            self._pagenumber = self.numpages
 
     @property
     def navlist(self):

--- a/plone/batching/batch.py
+++ b/plone/batching/batch.py
@@ -56,19 +56,22 @@ class BaseBatch(object):
         self.end = end
 
         self.first = max(start - 1, 0)
-        if self.beyond:
-            self.first = self.end
-        self.length = self.end - self.first
-
         self.last = self.sequence_length - size
 
         # Set up the total number of pages
         self.numpages = calculate_pagenumber(
             self.sequence_length - self.orphan, self.pagesize, self.overlap)
 
-        # Set up the current page number
-        self._pagenumber = calculate_pagenumber(
-            self.start, self.pagesize, self.overlap)
+        if self.beyond:
+            self.first = self.end
+            # Make sure current page number is not > numpages
+            self._pagenumber = self.numpages
+        else:
+            # Set up the current page number
+            self._pagenumber = calculate_pagenumber(
+                self.start, self.pagesize, self.overlap)
+
+        self.length = self.end - self.first
 
     @property
     def navlist(self):

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -156,6 +156,17 @@ class TestBatch(unittest.TestCase):
         batch = BaseBatch(range(12), 10)
         self.assertEquals(batch.multiple_pages, True)
 
+    def test_pagenumber_never_over_numpages(self):
+        """computed _pagenumber is never > numpages, this
+           makes previous_pages not fail."""
+        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7], 3, 8)
+        self.assertEquals(batch.previous_pages, [1, 2])
+        self.assertEquals(batch._pagenumber, 3)
+        # works especially with orphan
+        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7], 3, 8, orphan=2)
+        self.assertEquals(batch.previous_pages, [1])
+        self.assertEquals(batch._pagenumber, 2)
+
 
 class TestQuantumBatch(unittest.TestCase):
 

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -109,7 +109,8 @@ class TestBatch(unittest.TestCase):
     def test_items_not_on_page(self):
         batch = BaseBatch(range(20), 5, start=5)
         self.assertEqual(batch.items_not_on_page,
-            [0, 1, 2, 3, 4, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+                         [0, 1, 2, 3, 4, 10, 11, 12,
+                          13, 14, 15, 16, 17, 18, 19])
         self.assertEqual(list(batch), [5, 6, 7, 8, 9])
 
     def test_batch_bsize(self):

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -159,13 +159,13 @@ class TestBatch(unittest.TestCase):
     def test_pagenumber_never_over_numpages(self):
         """computed _pagenumber is never > numpages, this
            makes previous_pages not fail."""
-        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7], 3, 8)
+        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3, 9)
+        self.assertEquals(batch.previous_pages, [1, 2, 3])
+        self.assertEquals(batch._pagenumber, 4)
+        # works especially with orphan
+        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3, 9, orphan=2)
         self.assertEquals(batch.previous_pages, [1, 2])
         self.assertEquals(batch._pagenumber, 3)
-        # works especially with orphan
-        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7], 3, 8, orphan=2)
-        self.assertEquals(batch.previous_pages, [1])
-        self.assertEquals(batch._pagenumber, 2)
 
 
 class TestQuantumBatch(unittest.TestCase):

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -194,8 +194,7 @@ class TestBrowser(unittest.TestCase):
         request = TestRequest(form={'a': 'foo', 'c': 'bar'})
         setattr(request, 'ACTUAL_URL', 'http://nohost/dummy')
         view = PloneBatchView(None, request)
-        rendered = view(batch, ['a', 'b'])
-
+        view(batch, ['a', 'b'])
         self.assertEqual(view.make_link(3),
                          'http://nohost/dummy?a=foo&b_start:int=6')
 


### PR DESCRIPTION
Hi @gforcada @do3cc 

Actually, when using orphan, if you specify a b_start that is in the "orphan" scope, it fails in previous_pages.

Lets say I have 11 elements, displayed by 3 with 2 orphans.  Pages of 3/3/5 elements.  If I use a b_start of 10, it will try to get the page number 4, but actually we have only 3 pages because of orphan...

Could you please review and merge this?

Thank you ;-)

Gauthier