### PR TITLE
omit ajax_load in urls by default via new omit_params parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ Changelog
 
 New:
 
-- *add item here*
+- Introduce a "omit_params" option for the ``make_link`` method and filter out
+  ``ajax_load`` by default. When loading the contents with batchnavigation via
+  ajax, it doesn't render the links with ajax_load enabled, which would
+  probably lead to usability troubles.
+  [thet]
 
 Fixes:
 

--- a/plone/batching/browser.py
+++ b/plone/batching/browser.py
@@ -38,23 +38,25 @@ class BootstrapBatchView(BatchView):
 
 class PloneBatchView(BatchView):
 
-    def make_link(self, pagenumber=None):
-        form = self.request.form
+    def make_link(self, pagenumber=None, omit_params=['ajax_load']):
+        query_params = {}
+        query_params.update(self.request.form)
         if self.batchformkeys:
-            batchlinkparams = dict([(key, form[key])
-                                    for key in self.batchformkeys
-                                    if key in form])
-        else:
-            batchlinkparams = form.copy()
+            for key in query_params.keys():
+                if key not in self.batchformkeys:
+                    del query_params[key]
+        if omit_params:
+            for key in omit_params:
+                if key in query_params:
+                    del query_params[key]
 
         start = max(pagenumber - 1, 0) * self.batch.pagesize
-        return "{0}?{1}".format(
+        query_params[self.batch.b_start_str] = start
+        url = u'{0}?{1}'.format(
             self.request.ACTUAL_URL,
-            make_query(
-                batchlinkparams,
-                {self.batch.b_start_str: start}
-            )
+            make_query(query_params)
         )
+        return url
 
 
 class PloneBootstrapBatchView(BootstrapBatchView, PloneBatchView):

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -219,6 +219,17 @@ class TestBrowser(unittest.TestCase):
         self.assertEqual(view.make_link(3),
                          'http://nohost/dummy?a=foo&b_start:int=6')
 
+    def test_batchview_plone_ajax_load(self):
+        from zope.publisher.browser import TestRequest
+        batch = BaseBatch([1, 2, 3, 4, 5, 6, 7], 3)
+        request = TestRequest(form={'a': 'foo', 'ajax_load': 1})
+        setattr(request, 'ACTUAL_URL', 'http://nohost/dummy')
+        view = PloneBatchView(None, request)
+        view(batch)  # don't set allowed params (batchformkeys) like above.
+        # allow all, but filter for ajax_load separately
+        self.assertEqual(view.make_link(3),
+                         'http://nohost/dummy?a=foo&b_start:int=6')
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Introduce a omit_params option for the make_link method and filter out ajax_load by default. When loading the contents with batchnavigation via ajax, it doesn't render the links with ajax_load enabled, which would probably lead to usability troubles like loading the site without the plone border.