### PR TITLE
Use context.absolute_url instead request.ACTUAL_URL for generating batch links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,15 @@ Changelog
 
 New:
 
+- For generating the batching urls, don't use ACTUAL_URL, but the context's
+  absolute_url. This allows for mutliple batchnavigations on different contexts
+  shown on one page via some collage or mosaic view.
+  ATTENTION: CAN'T BE DONE THAT WAY!
+  PROBLEM: On views, which are no defaultView but explicitly called (e.g.
+  ``@@folder_contents``), the links would be generated wrong. Couldn't
+  determine the actual shown view within one request cycle, so I gave up on
+  this. It's just a corne use case anyways...
+
 - Introduce a "omit_params" option for the ``make_link`` method and filter out
   ``ajax_load`` by default. When loading the contents with batchnavigation via
   ajax, it doesn't render the links with ajax_load enabled, which would

--- a/plone/batching/browser.py
+++ b/plone/batching/browser.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_parent
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import queryMultiAdapter
 from ZTUtils import make_query
+
 
 BatchTemplate = ViewPageTemplateFile("batchnavigation.pt")
 BootstrapBatchTemplate = ViewPageTemplateFile("batchnavigation_bootstrap.pt")
@@ -50,10 +53,23 @@ class PloneBatchView(BatchView):
                 if key in query_params:
                     del query_params[key]
 
+        def _get_context(ctx):
+            """Return the context which should be used to generate the url.
+            If it's a default view, return walk up the hierachy until the
+            originating context is found.
+            """
+            # Plone soft-dependency. If no adapter is found, just return ctx.
+            context_state = queryMultiAdapter(
+                (ctx, self.request), name='plone_context_state')
+            if context_state and context_state.is_default_page():
+                return _get_context(aq_parent(ctx))
+            return ctx
+        context = _get_context(self.context)
+
         start = max(pagenumber - 1, 0) * self.batch.pagesize
         query_params[self.batch.b_start_str] = start
-        url = u'{0}?{1}'.format(
-            self.request.ACTUAL_URL,
+        url = u"{0}?{1}".format(
+            context.absolute_url(),
             make_query(query_params)
         )
         return url


### PR DESCRIPTION
For generating the batching urls, don't use ACTUAL_URL, but the context's absolute_url.
This allows for mutliple batchnavigations on different contexts shown on one page via some collage or mosaic view.

ATTENTION: CAN'T BE DONE THAT WAY!

PROBLEM: On views, which are no defaultView but explicitly called (e.g. @@folder_contents), the links would be generated wrong.
Couldn't determine the actual shown view within one request cycle, so I gave up on this.
It's just a corne use case anyways...

This pull request is just for documentation. I'll close it right away.