### PR TITLE
Added support for slicing in Batch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Batch now support slicing. It returns a new batch with same configuration but on a subset of the original sequence.
+  [keul]
 
 Bug fixes:
 

--- a/plone/batching/batch.py
+++ b/plone/batching/batch.py
@@ -51,7 +51,6 @@ class BaseBatch(object):
         """
         start, end, sz = opt(start, end, size, self.orphan,
                              self.sequence_length)
-
         self.pagesize = sz
         self.start = start
         self.end = end
@@ -145,6 +144,16 @@ class BaseBatch(object):
     def __getitem__(self, index):
         """ Get item from batch
         """
+        if type(index)==slice:
+            new_sequence = self._sequence.__getslice__(
+                index.start or 0,
+                self.sequence_length if index.stop is None else index.stop
+            )
+            return BaseBatch(
+                new_sequence, self._size,
+                orphan=self.orphan, overlap=self.overlap,
+                pagerange=self.pagerange
+            )
         actual = getattr(self._sequence, 'actual_result_count', None)
         if (actual is not None and actual != len(self._sequence)
                 and index < self.length):

--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -176,6 +176,21 @@ class TestBatch(unittest.TestCase):
         self.assertEquals(batch.previous_pages, [1, 2])
         self.assertEquals(batch._pagenumber, 3)
 
+    def test_slicing(self):
+        """slicing on a batch returns a smaller batch with same configuration
+        """
+        batch = BaseBatch(range(20), 5, 4)
+        new_batch = batch[4:]
+        self.assertEquals(new_batch[0], 8)
+        self.assertEquals(new_batch[-1], 12)
+        self.assertEquals(len(new_batch), 16)
+        self.assertEquals(new_batch._pagenumber, 1)
+        new_batch = batch[4:12]
+        self.assertEquals(new_batch[0], 8)
+        self.assertEquals(new_batch[-1], 11)
+        self.assertEquals(len(new_batch), 8)
+        self.assertEquals(new_batch._pagenumber, 1)
+
 
 class TestQuantumBatch(unittest.TestCase):
 


### PR DESCRIPTION
Batch object do not support slice operator.

Usecase: we have a batch object but we need batching behavior only on a subset of the sequence.