### PR TITLE
Add a test that shows the different behavior in Python 2.7 and Python…

### DIFF
--- a/plone/batching/tests.py
+++ b/plone/batching/tests.py
@@ -12,6 +12,7 @@ from plone.batching.utils import calculate_quantum_leap_gap
 from plone.batching.utils import opt
 from zope.component.testing import setUp
 from zope.component.testing import tearDown
+
 import doctest
 import unittest
 
@@ -70,6 +71,43 @@ class TestBatch(unittest.TestCase):
     def test_previous_first(self):
         batch = BaseBatch(range(20), 5)
         self.assertFalse(batch.previous)
+
+    def test_navlist_no_pagerange(self):
+        # Well, actually with a default pagerange (7)
+        # greater than the number of pages: all pages should be displayed
+
+        for start in range(20):
+            batch = BaseBatch(range(20), 5, start)
+            self.assertListEqual(list(batch.navlist), [1, 2, 3, 4])
+
+    def test_navlist_with_pagerange(self):
+        # Until we reach page 3 we have 3 pages centered on 2
+        for start in range(0, 10):
+            batch = BaseBatch(range(20), 5, start, pagerange=3)
+            self.assertListEqual(
+                list(batch.navlist),
+                [1, 2, 3],
+                'Failing when starting at {}'.format(start)
+            )
+
+        # then we have 3 pages centered on page 3
+        for start in range(10, 15):
+            batch = BaseBatch(range(20), 5, start, pagerange=3)
+            self.assertListEqual(
+                list(batch.navlist),
+                [2, 3, 4],
+                'Failing when starting at {}'.format(start)
+            )
+
+        # XXX I consider this an errorm it should be [2, 3, 4]
+        # when we are at the last page we have two pages starting at 3
+        for start in range(15, 20):
+            batch = BaseBatch(range(20), 5, start, pagerange=3)
+            self.assertListEqual(
+                list(batch.navlist),
+                [3, 4],
+                'Failing when starting at {}'.format(start)
+            )
 
     def test_previous(self):
         batch = BaseBatch(range(20), 5, 5)


### PR DESCRIPTION
… 3.6

```
[ale@emily plone3]$ .tox/py27/bin/test -s plone.batching 
/home/ale/.buildout/eggs/AccessControl-4.0b4-py2.7-linux-x86_64.egg/AccessControl/ZopeGuards.py:46: DeprecationWarning: the sets module is deprecated
  import sets
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
                  
  Ran 33 tests with 0 failures, 0 errors, 0 skipped in 0.096 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
✓ ~/Code/plone/plone3 (5.2) 
[ale@emily plone3]$ .tox/py36/bin/test -s plone.batching 
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    20/33 (60.6%)/home/ale/Code/plone/plone3/src/plone.batching/plone/batching/tests.py:199: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(batch.multiple_pages, False)
    24/33 (72.7%)

Failure in test test_navlist_with_pagerange (plone.batching.tests.TestBatch)
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/home/ale/Code/plone/plone3/src/plone.batching/plone/batching/tests.py", line 99, in test_navlist_with_pagerange
    'Failing when starting at {}'.format(start)
  File "/usr/lib/python3.6/unittest/case.py", line 1028, in assertListEqual
    self.assertSequenceEqual(list1, list2, msg, seq_type=list)
  File "/usr/lib/python3.6/unittest/case.py", line 1010, in assertSequenceEqual
    self.fail(msg)
  File "/usr/lib/python3.6/unittest/case.py", line 670, in fail
    raise self.failureException(msg)
AssertionError: Lists differ: [1, 2, 3] != [2, 3, 4]

First differing element 0:
1
2

- [1, 2, 3]
+ [2, 3, 4] : Failing when starting at 10

                  
  Ran 33 tests with 1 failures, 0 errors, 0 skipped in 0.103 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```