### PR TITLE
Missing class "page-link" for ellipsis after first item

### DIFF
--- a/75.bugfix
+++ b/75.bugfix
@@ -1,0 +1,2 @@
+- Adds missing "page-link" class for first ellipsis
+[szakitibi]

--- a/plone/batching/batchnavigation.pt
+++ b/plone/batching/batchnavigation.pt
@@ -57,7 +57,7 @@
       <li class="page-item disabled"
           tal:condition="batch/second_page_not_in_navlist"
       >
-        <span>...</span>
+        <span class="page-link">...</span>
       </li>
 
       <tal:comment replace="nothing">


### PR DESCRIPTION
**What is happening:**

With a lot of results in Plone 6 Classic UI (e.g. in search results) the batching has no style applied for the first ellpisis:

![image](https://github.com/plone/plone.batching/assets/13345340/d7265aa1-d7e2-4a28-a07a-964fb572d398)

**What I expect:**

![image](https://github.com/plone/plone.batching/assets/13345340/b6e96518-f524-4a7b-88f9-ba5b0f9902ff)

See the original commit adding "page-link" class to the [after ellipsis](https://github.com/plone/plone.batching/commit/ce3a27b8d8b6956736abe4e7c8bb56fe34b9b4d8#diff-3aad594a40bd9502a8a32801f638dc39750ecfb2cb5cef4abd63a79bdaa00400R66) but missing to add the same class to the first one on line 35.

Adding the missing "page-link" class fixes the style.